### PR TITLE
fix(mootdx): 规避 0.11.7 BESTIP.HQ 空串导致的 ValueError

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -113,6 +113,61 @@ export IWENCAI_BASE_URL="https://openapi.iwencai.com"
 
 其他数据源（mootdx / 腾讯 / 东财 / 同花顺 / 百度股市通 / 新浪 / 巨潮）全部免费，无需 key。
 
+### mootdx 客户端（必读，规避 0.11.7 已知 bug）
+
+> **已知 bug（mootdx 0.11.7）：** `Quotes.factory(market='std')` 裸调用会触发 `ValueError: not enough values to unpack (expected 2, got 0)`。
+> 根因：`config.json` 中 `BESTIP.HQ` 初始值是空字符串 `""`（不是缺失键），`quotes.py:151` 用 `dict.get(key, default)` 取不到 default，`self.server = ""` 拆包失败。
+> 即便指定 `bestip=True` 测速也无法修复（测速结果写不回 `BESTIP.HQ`，且写入的是不在内置列表中的 IP）。
+> 海外/部分 ISP 网络下，38 个内置服务器中通常只有 ~14 个可达，必须 fallback 探测。
+
+**统一使用以下 helper 创建客户端（4 处 mootdx 调用都走它）：**
+
+```python
+import socket
+from mootdx.quotes import Quotes
+
+# 实测可用的备选服务器列表（按延迟排序，2026-05 验证）
+_TDX_SERVERS = [
+    ('119.97.185.59', 7709),    # 武汉电信主站1
+    ('124.70.133.119', 7709),   # 上海双线主站12
+    ('116.205.183.150', 7709),  # 广州双线主站7
+    ('123.60.73.44', 7709),     # 上海双线主站11
+    ('116.205.163.254', 7709),  # 广州双线主站5
+    ('121.36.225.169', 7709),   # 上海双线主站9
+    ('123.60.70.228', 7709),    # 上海双线主站10
+    ('124.71.9.153', 7709),     # 广州双线主站4
+    ('110.41.147.114', 7709),   # 深圳双线主站1
+    ('124.71.187.122', 7709),   # 上海双线主站14
+]
+
+def _probe(ip: str, port: int, timeout: float = 2.0) -> bool:
+    """TCP 握手探测"""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect((ip, port))
+        s.close()
+        return True
+    except Exception:
+        return False
+
+def tdx_client(market: str = 'std'):
+    """
+    创建 mootdx 客户端，规避 0.11.7 BESTIP.HQ 空串 bug。
+    顺序探测 _TDX_SERVERS，返回第一个 TCP 可达的服务器对应的客户端。
+    全部不通则抛 RuntimeError。
+    """
+    for ip, port in _TDX_SERVERS:
+        if _probe(ip, port):
+            return Quotes.factory(market=market, server=(ip, port))
+    raise RuntimeError("所有 mootdx 服务器均不可达，请检查网络或更新 _TDX_SERVERS 列表")
+
+# 使用方式（替代所有 Quotes.factory(market='std') 调用）
+# client = tdx_client()
+```
+
+> **海外 IP 用户：** mootdx 走通达信 TCP 7709 协议，海外环境通常全部超时。建议改用 yfinance 或走国内代理。`tdx_client()` 会快速失败给出明确报错而非死等。
+
 ### 市场前缀规则（全局通用）
 
 ```python
@@ -176,7 +231,7 @@ TCP 二进制协议，连通达信服务器(7709)，无需注册，不封IP。
 ```python
 from mootdx.quotes import Quotes
 
-client = Quotes.factory(market='std')
+client = tdx_client()  # 见 Prerequisites 中的 helper 定义（规避 0.11.7 bug）
 
 # === K线数据 ===
 # market: 0=深圳, 1=上海
@@ -1483,8 +1538,9 @@ for n in news[:10]:
 
 ```python
 from mootdx.quotes import Quotes
-
-client = Quotes.factory(market='std')
+# 注意：0.11.7 裸调用 Quotes.factory(market='std') 有 BESTIP.HQ 空串 bug。
+# 生产代码请用前述 tdx_client() helper；此处为演示底层调用。
+client = tdx_client()  # 见 Prerequisites 中的 helper 定义
 
 # market: 0=深圳, 1=上海
 fin = client.finance(symbol='688017')
@@ -1502,7 +1558,7 @@ fin = client.finance(symbol='688017')
 ```python
 from mootdx.quotes import Quotes
 
-client = Quotes.factory(market='std')
+client = tdx_client()  # 见 Prerequisites 中的 helper 定义
 
 # 9 大类文本数据:
 categories = [
@@ -1668,7 +1724,7 @@ for a in anns[:10]:
 
 ```python
 from mootdx.quotes import Quotes
-client = Quotes.factory(market='std')
+client = tdx_client()  # 见 Prerequisites 中的 helper 定义
 text = client.F10(symbol='688017', name='最新提示')
 # 包含最近的公告/分红/股东大会决议等摘要
 ```


### PR DESCRIPTION
## 问题

`Quotes.factory(market='std')` 裸调用在 mootdx 0.11.7 下会触发：

```
ValueError: not enough values to unpack (expected 2, got 0)
  at mootdx/quotes.py:154
```

按 SKILL.md V3.0 Prerequisites 安装 `pip install mootdx==0.11.7` 后，Layer 1.1 / 6.1 / 6.2 / 7.2 共 4 处 mootdx 调用全部受影响。

## 根因

mootdx 0.11.7 的 `~/.mootdx/config.json` 中 `BESTIP.HQ` 初始值是空字符串 `""`，而不是缺失键或 `null`。`quotes.py:151` 的逻辑：

```python
default = config.get('SERVER').get('HQ')[0][1:]
self.server = config.get('BESTIP').get('HQ', default)   # ← 这里 default 永远拿不到
```

`dict.get(key, default)` 仅在键缺失时返回 `default`。`BESTIP.HQ` 是**存在的空串**，所以 `self.server = ""`，下一行 `ip, port = self.server` 拆包失败。

另外两个补充发现：

1. **`bestip=True` 自动测速也无法修复** —— 测速跑完后写进 `BESTIP.HQ` 的是不在 SERVER.HQ 列表里的 IP（如 `218.6.170.47`），而且不通；
2. **38 个内置服务器并非都可达** —— 在我本地 ISP 实测仅 14 / 38 可用（武汉/上海双线/广州双线大部分通，深圳双线 6/8 个超时）。必须 fallback 探测。

## 改动

仅修改 `SKILL.md`：

1. 在 Prerequisites 末尾新增 **`mootdx 客户端（必读，规避 0.11.7 已知 bug）`** 章节，包含：
   - bug 触发条件、根因说明
   - 10 个实测可达服务器列表（按延迟排序，2026-05 验证）
   - `_probe()` TCP 握手探测函数
   - `tdx_client(market='std')` helper：顺序探测 fallback，全不通则 `RuntimeError`
2. 将 4 处 `client = Quotes.factory(market='std')` 调用替换为 `client = tdx_client()`：
   - Layer 1.1（K线 / 五档 / 逐笔）
   - Layer 6.1（财务快照）
   - Layer 6.2（F10 公司资料）
   - Layer 7.2（F10 公告摘要）

不动 README、CHANGELOG。

## 验证

将本地 `~/.mootdx/config.json` 的 `BESTIP.HQ` **还原为 `""`** 模拟全新安装环境，然后跑 SKILL.md 中的 helper：

| 调用点 | 结果 |
|---|---|
| Layer 1.1 `client.bars` | OK，server=`('119.97.185.59', 7709)` |
| Layer 1.1 `client.quotes` | OK |
| Layer 6.1 `client.finance` | OK |
| Layer 6.2 / 7.2 `client.F10` | OK，返回 14626 字符 |

## 备选方案讨论

也考虑过其它修法：

- **每处直接传 server**：4 处都写 `Quotes.factory(market='std', server=('119.97.185.59', 7709))`。优点最简单，缺点服务器挂了要 4 处手改。
- **仅加 Prerequisites 提示让用户改 config.json**：风险是用户漏读 / 不同环境 BESTIP.HQ 已被破坏到不同状态。
- **不动 SKILL.md，去 mootdx 上游修**：上游修复要等版本发布；这里作为 Skill 文档先 ship 一个对调用者更友好的 workaround，更稳。

选了 `tdx_client()` helper 方案 —— 单点维护（升级 mootdx 后 helper 内部就只剩"探测 fallback"价值，可保留为容灾），调用方零认知负担。

## 不影响

- README / CHANGELOG / 其它非 mootdx 端点的代码未改
- 不引入新依赖（`socket` 是标准库）
- `_TDX_SERVERS` 是从仓库 `~/.mootdx/config.json` 的内置 `SERVER.HQ` 子集中挑出来的实测可达项，无新数据源

> 注：本 PR 不试图修复 mootdx 上游 bug 本身（那需要修 `quotes.py:151` 的 default fallback 逻辑，应由 mootdx 维护者决定）。这里只是把 Skill 用户从这个坑里救出来。
