### PR TITLE
fix: eastmoney_stock_news 兼容 cmsArticleWebOld 直接返回 list

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1361,7 +1361,9 @@ def eastmoney_stock_news(code: str, page_size: int = 20) -> list[dict]:
     d = json.loads(json_str)
 
     rows = []
-    articles = d.get("result", {}).get("cmsArticleWebOld", {}).get("list", [])
+    # cmsArticleWebOld 可能直接返回 list，也可能是 {"list": [...]}，做兼容
+    cw = d.get("result", {}).get("cmsArticleWebOld")
+    articles = cw if isinstance(cw, list) else (cw or {}).get("list", [])
     for a in articles:
         rows.append({
             "title": re.sub(r'<[^>]+>', '', a.get("title", "")),


### PR DESCRIPTION
## 问题
`eastmoney_stock_news()` 在解析东财搜索接口时报错：

```
AttributeError: 'list' object has no attribute 'get'
```

定位到 SKILL.md 中：

```python
articles = d.get("result", {}).get("cmsArticleWebOld", {}).get("list", [])
```

实测（2026-05-20）东财接口 `result.cmsArticleWebOld` 字段会**直接返回文章 list**，而不是 `{"list": [...]}`，因此多套的 `.get("list")` 在 list 上调用就抛异常。

## 修复
改为对返回类型做自适应：

```python
cw = d.get("result", {}).get("cmsArticleWebOld")
articles = cw if isinstance(cw, list) else (cw or {}).get("list", [])
```

## 验证
对 `603019`(中科曙光)、`688017`(绿的谐波) 回归，均能正常返回新闻列表（title/content/time/source/url）。

感谢这个非常实用的工具包 🙏