### PR TITLE
fix: §7.1 cninfo_announcements orgId 改为动态查询（替代硬编码）

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1704,19 +1704,43 @@ def _cninfo_ts_to_date(ts):
         return datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d")
     return str(ts)[:10] if ts else ""
 
+_cninfo_orgid_cache = None
+
+def _get_cninfo_orgid(code: str) -> str:
+    """从巨潮 stock list 动态查询真实 orgId（带缓存），失败时回退硬编码。"""
+    global _cninfo_orgid_cache
+    if _cninfo_orgid_cache is None:
+        _cninfo_orgid_cache = {}
+        try:
+            r = requests.get(
+                "http://www.cninfo.com.cn/new/data/szse_stock.json",
+                headers={"User-Agent": UA},
+                timeout=10,
+            )
+            data = r.json()
+            _cninfo_orgid_cache = {
+                s["code"]: s["orgId"] for s in data.get("stockList", [])
+            }
+        except Exception:
+            pass
+
+    if code in _cninfo_orgid_cache:
+        return _cninfo_orgid_cache[code]
+    # fallback: 硬编码（覆盖未收录或网络不可达的情况）
+    if code.startswith("6"):
+        return f"gssh0{code}"
+    elif code.startswith("8") or code.startswith("4"):
+        return f"gsbj0{code}"
+    else:
+        return f"gssz0{code}"
+
 def cninfo_announcements(code: str, page_size: int = 30) -> list[dict]:
     """
     巨潮公告全文检索。
     返回: [{title, type, date, url}]
     """
     url = "https://www.cninfo.com.cn/new/hisAnnouncement/query"
-    # 构造 orgId（巨潮 2026 新格式）
-    if code.startswith("6"):
-        org_id = f"gssh0{code}"
-    elif code.startswith("8") or code.startswith("4"):
-        org_id = f"gsbj0{code}"
-    else:
-        org_id = f"gssz0{code}"
+    org_id = _get_cninfo_orgid(code)
 
     payload = {
         "stock": f"{code},{org_id}",

--- a/SKILL.md
+++ b/SKILL.md
@@ -1710,7 +1710,6 @@ def _get_cninfo_orgid(code: str) -> str:
     """从巨潮 stock list 动态查询真实 orgId（带缓存），失败时回退硬编码。"""
     global _cninfo_orgid_cache
     if _cninfo_orgid_cache is None:
-        _cninfo_orgid_cache = {}
         try:
             r = requests.get(
                 "http://www.cninfo.com.cn/new/data/szse_stock.json",
@@ -1722,7 +1721,8 @@ def _get_cninfo_orgid(code: str) -> str:
                 s["code"]: s["orgId"] for s in data.get("stockList", [])
             }
         except Exception:
-            pass
+            import warnings
+            warnings.warn("cninfo orgId 映射加载失败，将回退硬编码格式")
 
     if code in _cninfo_orgid_cache:
         return _cninfo_orgid_cache[code]


### PR DESCRIPTION
修复 #19

## 问题

`cninfo_announcements()` 通过规则硬编码 orgId：
```python
if code.startswith("6"):
    org_id = f"gssh0{code}"
...
```

但巨潮的 orgId 并非统一的 `gssx0{code}` 格式。大量股票（如 601318 中国平安、601398 工商银行、601857 中国石油等）的实际 orgId 是完全不同的编码（如 `9900002221`、`jjxt0000019`），导致 `cninfo_announcements()` 静默返回空。

详见 #19。

## 改动

- 新增 `_cninfo_orgid_cache` 模块级变量 + `_get_cninfo_orgid()` 辅助函数
- 首次调用时从 cninfo 公开接口 `/new/data/szse_stock.json` 拉取全量股票→orgId 映射（~6195 只），后续走模块级缓存
- 查询失败时回退原硬编码逻辑以保证兼容性

## 验证

| 股票 | 改动前 | 改动后 |
|------|--------|--------|
| 601318 中国平安 | 0 条 ✗ | 2037 条 ✅ |
| 601398 工商银行 | 0 条 ✗ | 2064 条 ✅ |
| 601857 中国石油 | 0 条 ✗ | 1234 条 ✅ |
| 601166 兴业银行 | 0 条 ✗ | 1379 条 ✅ |
| 600519 贵州茅台 | 1268 条 ✓ | 1268 条 ✅ |
| 600036 招商银行 | 2202 条 ✓ | 2202 条 ✅ |
| 688017 绿的谐波 | 硬编码格式 ✗ | 621 条 ✅ |
| 000001 平安银行 | 1980 条 ✓ | 1980 条 ✅ |